### PR TITLE
 Split CI To Build Testnet And Mainnet Images Based On Branches

### DIFF
--- a/.github/workflows/build-and-publish-mainnet.yml
+++ b/.github/workflows/build-and-publish-mainnet.yml
@@ -1,0 +1,88 @@
+name: BuildAndPublishMainNet
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update Apt
+        run: sudo apt update
+
+      - name: Install TzData
+        run: env DEBIAN_FRONTEND="noninteractive" sudo apt install -y tzdata
+
+      - name: Install OpenStack, Packer, JQ, and Envsubst
+        run: sudo apt install -y python3-openstackclient python3-novaclient packer jq gettext-base
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: themeliolabs/actions-biome@v1
+        with:
+          BIOME_PUBLIC_KEY: ${{ secrets.BIOME_PUBLIC_KEY }}
+          BIOME_SIGNING_KEY: ${{ secrets.BIOME_SIGNING_KEY }}
+
+      - name: Remove Rust
+        run: sudo rm -rf /usr/share/rust/
+
+      - name: Remove Rustc
+        run: sudo rm -rf /home/runner/.cargo/bin/rustc
+
+      - name: Remove Cargo
+        run: sudo rm -rf /home/runner/.cargo/bin/cargo
+
+      - name: Fix Directory Permissions
+        run: sudo chown -R $(whoami):$(id -ng) /hab
+
+      - name: Cache Biome
+        uses: actions/cache@v2
+        env:
+          CACHE_NAME: cache-biome
+        with:
+          path: |
+            ~/.hab/cache/artifacts
+            /hab/cache/artifacts
+            /hab/pkgs
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('biome/themelio-node/plan-release.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.CACHE_NAME }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Build, Publish Artifact And Mark As Stable, Export And Publish Docker Image, Create Packer Images
+        env:
+          HAB_ORIGIN: "themelio"
+          BIOME_PUBLIC_KEY: ${{ secrets.BIOME_PUBLIC_KEY }}
+          HAB_BLDR_URL: "https://bldr.habitat.sh"
+          BIOME_BLDR_URL: "https://bldr.biome.sh"
+          BIOME_AUTH_TOKEN: ${{ secrets.BIOME_AUTH_TOKEN }}
+          HABITAT_AUTH_TOKEN: ${{ secrets.HABITAT_AUTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMTAIL_USERNAME: ${{ secrets.PROMTAIL_USERNAME }}
+          PROMTAIL_PASSWORD: ${{ secrets.PROMTAIL_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+#          OS_AUTH_URL: ${{ secrets.OS_AUTH_URL }}
+#          OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
+#          OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
+#          OS_USER_DOMAIN_NAME: ${{ secrets.OS_USER_DOMAIN_NAME }}
+#          OS_USERNAME: ${{ secrets.OS_USERNAME }}
+#          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          NETWORK_TO_BUILD: "mainnet"
+        run: ./biome/themelio-node/scripts/ci-publish.sh

--- a/.github/workflows/build-and-publish-testnet.yml
+++ b/.github/workflows/build-and-publish-testnet.yml
@@ -1,8 +1,9 @@
-name: BuildAndPublish
+name: BuildAndPublishTestNet
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - testnet
 
 env:
   CARGO_TERM_COLOR: always
@@ -83,4 +84,5 @@ jobs:
 #          OS_USER_DOMAIN_NAME: ${{ secrets.OS_USER_DOMAIN_NAME }}
 #          OS_USERNAME: ${{ secrets.OS_USERNAME }}
 #          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          NETWORK_TO_BUILD: "testnet"
         run: ./biome/themelio-node/scripts/ci-publish.sh

--- a/.github/workflows/build-and-test-mainnet.yml
+++ b/.github/workflows/build-and-test-mainnet.yml
@@ -1,8 +1,9 @@
 name: BuildAndTestMainNet
 
 on:
-  pull_request:
-    branches: [ master ]
+  push:
+    branches:
+      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-and-test-mainnet.yml
+++ b/.github/workflows/build-and-test-mainnet.yml
@@ -1,4 +1,4 @@
-name: BuildAndTest
+name: BuildAndTestMainNet
 
 on:
   pull_request:
@@ -57,4 +57,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          NETWORK_TO_BUILD: "mainnet"
         run: ./biome/themelio-node/scripts/ci-test.sh

--- a/.github/workflows/build-and-test-testnet.yml
+++ b/.github/workflows/build-and-test-testnet.yml
@@ -1,0 +1,62 @@
+name: BuildAndTestTestNet
+
+on:
+  pull_request:
+    branches:
+      - testnet
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  biome:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: themeliolabs/actions-biome@v1
+        with:
+          BIOME_PUBLIC_KEY: ${{ secrets.BIOME_PUBLIC_KEY }}
+          BIOME_SIGNING_KEY: ${{ secrets.BIOME_SIGNING_KEY }}
+
+      - name: Fix Directory Permissions
+        run: sudo chown -R $(whoami):$(id -ng) /hab
+
+      - name: Remove Rust
+        run: sudo rm -rf /usr/share/rust/
+
+      - name: Remove Rustc
+        run: sudo rm -rf /home/runner/.cargo/bin/rustc
+
+      - name: Remove Cargo
+        run: sudo rm -rf /home/runner/.cargo/bin/cargo
+
+      - name: Cache Biome
+        uses: actions/cache@v2
+        env:
+          CACHE_NAME: cache-biome
+        with:
+          path: |
+            ~/.hab/cache/artifacts
+            /hab/cache/artifacts
+            /hab/pkgs
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('biome/themelio-node/plan-debug.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.CACHE_NAME }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Build, Run BATS Tests
+        env:
+          HAB_ORIGIN: "themelio"
+          BIOME_PUBLIC_KEY: ${{ secrets.BIOME_PUBLIC_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMTAIL_USERNAME: ${{ secrets.PROMTAIL_USERNAME }}
+          PROMTAIL_PASSWORD: ${{ secrets.PROMTAIL_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          NETWORK_TO_BUILD: "testnet"
+        run: ./biome/themelio-node/scripts/ci-test.sh

--- a/.github/workflows/musl-tests.yml
+++ b/.github/workflows/musl-tests.yml
@@ -2,7 +2,9 @@ name: MuslTests
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - testnet
 
 env:
   CARGO_TERM_COLOR: always

--- a/biome/themelio-node/scripts/ci-publish.sh
+++ b/biome/themelio-node/scripts/ci-publish.sh
@@ -60,26 +60,55 @@ done
 
 mkdir -p ${SCRIPTS_DIRECTORY}/packer/temporary-templates
 
-for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
-  echo "Creating packer templates for the $region region."
+if [ "${NETWORK_TO_BUILD}" == "mainnet" ]; then
+  for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
+    echo "Creating packer templates for $region-$NETWORK_TO_BUILD."
 
-  export AWS_REGION=${region}
+    export AWS_REGION=${region}
 
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/mainnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/mainnet-$region.pkr.hcl"
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/testnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/testnet-$region.pkr.hcl"
-done
+    envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
+    envsubst < "${SCRIPTS_DIRECTORY}/packer/mainnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/mainnet-$region.pkr.hcl"
+  done
 
-echo "Joining packer templates"
-sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp
-envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl"
+  echo "Joining packer templates"
+  sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp
+  envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl"
 
-echo "Cleaning up temporary files"
-rm ${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp
-rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
+  echo "Cleaning up temporary files"
+  rm ${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp
+  rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
 
-echo "Validating packer template"
-packer validate "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl"
+  echo "Validating packer mainnet template"
+  packer validate "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl"
 
-echo "Building packer images"
-packer build "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl"
+  echo "Building packer mainnet images"
+  packer build "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl"
+
+elif [ "${NETWORK_TO_BUILD}" == "testnet" ]; then
+  for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
+      echo "Creating packer templates for $region-$NETWORK_TO_BUILD."
+
+      export AWS_REGION=${region}
+
+      envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
+      envsubst < "${SCRIPTS_DIRECTORY}/packer/testnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/testnet-$region.pkr.hcl"
+    done
+
+    echo "Joining packer templates"
+    sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp
+    envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl"
+
+    echo "Cleaning up temporary files"
+    rm ${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp
+    rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
+
+    echo "Validating packer testnet template"
+    packer validate "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl"
+
+    echo "Building packer testnet images"
+    packer build "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl"
+
+else
+  echo "No network specified with NETWORK_TO_BUILD. Exiting."
+  exit 1
+fi

--- a/biome/themelio-node/scripts/ci-test.sh
+++ b/biome/themelio-node/scripts/ci-test.sh
@@ -57,23 +57,49 @@ fi
 
 mkdir -p ${SCRIPTS_DIRECTORY}/packer/temporary-templates
 
-for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
-  echo "Creating packer templates for the $region region."
+if [ "${NETWORK_TO_BUILD}" == "mainnet" ]; then
+  for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
+    echo "Creating packer templates for $region-$NETWORK_TO_BUILD."
 
-  export AWS_REGION=${region}
+    export AWS_REGION=${region}
 
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/mainnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/mainnet-$region.pkr.hcl"
-  envsubst < "${SCRIPTS_DIRECTORY}/packer/testnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/testnet-$region.pkr.hcl"
-done
+    envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
+    envsubst < "${SCRIPTS_DIRECTORY}/packer/mainnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/mainnet-$region.pkr.hcl"
+  done
 
-echo "Joining packer templates"
-sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp
-envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl"
+  echo "Joining packer templates"
+  sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp
+  envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl"
 
-echo "Cleaning up temporary files"
-rm ${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl.temp
-rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
+  echo "Cleaning up temporary files"
+  rm ${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl.temp
+  rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
 
-echo "Validating packer template"
-packer validate "${SCRIPTS_DIRECTORY}/themelio-node-debian-aws.pkr.hcl"
+  echo "Validating packer mainnet template"
+  packer validate "${SCRIPTS_DIRECTORY}/themelio-node-mainnet-debian-aws.pkr.hcl"
+
+elif [ "${NETWORK_TO_BUILD}" == "testnet" ]; then
+  for region in $(cat $SCRIPTS_DIRECTORY/packer/aws_regions); do
+      echo "Creating packer templates for $region-$NETWORK_TO_BUILD."
+
+      export AWS_REGION=${region}
+
+      envsubst < "${SCRIPTS_DIRECTORY}/packer/base-image.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/base-image-$region.pkr.hcl"
+      envsubst < "${SCRIPTS_DIRECTORY}/packer/testnet.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/packer/temporary-templates/testnet-$region.pkr.hcl"
+    done
+
+    echo "Joining packer templates"
+    sed -e '$s/$/\n/' -s ${SCRIPTS_DIRECTORY}/packer/temporary-templates/*.hcl > ${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp
+    envsubst < "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp" > "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl"
+
+    echo "Cleaning up temporary files"
+    rm ${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl.temp
+    rm -rf ${SCRIPTS_DIRECTORY}/packer/temporary-templates
+
+    echo "Validating packer testnet template"
+    packer validate "${SCRIPTS_DIRECTORY}/themelio-node-testnet-debian-aws.pkr.hcl"
+
+else
+  echo "No network specified with NETWORK_TO_BUILD. Exiting."
+  exit 1
+fi


### PR DESCRIPTION
* Added a testnet branch flag to part of the CI.

* Testing syntax.

* Split the CI into networks.

* Working on the CI scripts.

* Working on the CI scripts.

* Uncommented a build block.

* Added network comments.

* Updated the CI publish script.